### PR TITLE
Add control flow trap fragment option

### DIFF
--- a/kernelHunter.py
+++ b/kernelHunter.py
@@ -17,6 +17,7 @@ from genetic_reservoir import GeneticReservoir
 from memory_pressure_mutation import generate_memory_pressure_fragment
 from advanced_crossover import crossover_shellcodes_advanced
 from cache_pollution_attack import generate_cache_pollution_fragment
+from control_flow_traps import generate_control_flow_trap_fragment
 
 def format_shellcode_c_array(shellcode_bytes):
     return ','.join(f'0x{b:02x}' for b in shellcode_bytes)
@@ -223,12 +224,13 @@ def generate_random_instruction():
         "full_kernel_syscall", #todas las syscalls disponicles del kernel
         "memory_pressure",
         "cache_pollution",
+        "control_flow_trap",
     ]
 
     #weights = [100, 0, 0, 0, 0, 0, 0, 0, 0]  # Probabilidades relativas
     #weights = [5, 0, 30, 0, 20, 0, 0, 5, 0, 30]  # Probabilidades relativas
     #weights = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,0,100]
-    weights = [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 15,5,5]
+    weights = [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 15, 5, 5, 5]
 
     choice_type = random.choices(options, weights=weights)[0]
 
@@ -272,6 +274,9 @@ def generate_random_instruction():
         
     elif choice_type == "cache_pollution":
         return generate_cache_pollution_fragment(min_ops=5, max_ops=15)
+
+    elif choice_type == "control_flow_trap":
+        return generate_control_flow_trap_fragment(min_instr=2, max_instr=6)
 
     elif choice_type == "memory_access":
         # Instrucciones que acceden a memoria, más probabilidad de fallos


### PR DESCRIPTION
## Summary
- wire `control_flow_traps` into `kernelHunter.py`
- support new `control_flow_trap` instruction choice

## Testing
- `python -m py_compile kernelHunter.py`

------
https://chatgpt.com/codex/tasks/task_e_683c4558d2dc83258e5d3126b4e30451