### PR TITLE
Simplify shellcode addition in crash UI

### DIFF
--- a/genetic_reservoir.py
+++ b/genetic_reservoir.py
@@ -234,6 +234,23 @@ class GeneticReservoir:
                 return True
         
         return False
+
+    def add_simple(self, shellcode, crash_info=None):
+        """Adds shellcode without diversity checks, only avoiding duplicates."""
+        for existing in self.reservoir:
+            if shellcode == existing:
+                print("Shellcode rejected: Duplicate")
+                return False
+
+        if len(self.reservoir) >= self.max_size:
+            self.reservoir.pop(0)
+
+        self.reservoir.append(shellcode)
+        self.extract_features(shellcode)
+        if crash_info:
+            self.crash_types.add(crash_info.get("crash_type", "unknown"))
+        print(f"Added shellcode to reservoir (size now: {len(self.reservoir)})")
+        return True
     
     def get_sample(self, n=1):
         """

--- a/kernel_crash_ui.py
+++ b/kernel_crash_ui.py
@@ -383,9 +383,13 @@ def add_parent_dna_to_reservoir(crash):
         input("Press ENTER to continue...")
         return
 
+    # Show a quick preview of the shellcode bytes
+    preview = " ".join(f"{b:02x}" for b in shellcode_bytes[:8])
+    print(f"Shellcode preview: {preview}")
+
     reservoir = GeneticReservoir()
     reservoir.load_from_file('kernelhunter_reservoir.pkl')
-    if reservoir.add(shellcode_bytes):
+    if reservoir.add_simple(shellcode_bytes):
         print("Shellcode added to genetic reservoir.")
     else:
         print("Shellcode rejected or already present.")


### PR DESCRIPTION
## Summary
- add `add_simple` to `GeneticReservoir` for duplicate-only insertion
- show a preview when adding shellcode from kernel_crash_ui option 15
- skip diversity checks by calling `add_simple`

## Testing
- `python -m py_compile kernel_crash_ui.py genetic_reservoir.py`

------
https://chatgpt.com/codex/tasks/task_e_683f5608566c8325a6987a5f9d704bda