### PR TITLE
Improve shellcode analysis sorting

### DIFF
--- a/reservoir_ui.py
+++ b/reservoir_ui.py
@@ -179,17 +179,25 @@ class ReservoirUI:
             lines.append(f"  0x{b:02x}: {counter[b]}")
 
         # Detect known instruction patterns
-        found = set()
+        from collections import Counter
+
+        found = Counter()
         for i in range(len(shellcode)):
             desc = interpret_instruction(shellcode[i:i+8])
             if desc != "instrucción desconocida":
-                found.add(desc)
+                found[desc] += 1
+
         lines.append("Known instructions detected:")
         if found:
-            for d in sorted(found):
+            for d, cnt in found.most_common():
                 lines.append(f"  - {d}")
         else:
             lines.append("  None")
+
+        if found:
+            lines.append("Instruction occurrences:")
+            for d, cnt in found.most_common():
+                lines.append(f"  {d}: {cnt}")
 
         return lines
 


### PR DESCRIPTION
## Summary
- show known instructions ordered by frequency
- list instruction occurrences after known instruction report

## Testing
- `python -m py_compile reservoir_ui.py`
- `python - <<'PY'
import reservoir_ui
print('loaded')
PY` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_683f8eaa566c83259a6de6f23a6c4acb