### PR TITLE
Installer now configures global or user settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,13 @@ source ~/.bashrc
 kernelhunter
 ```
 
-After installation, KernelHunter will be available globally for the current user under `~/.local/bin/kernelhunter`.
+After installation, KernelHunter will be available under `~/.local/bin/kernelhunter` for the current user. During installation you can choose whether the configuration is stored globally in `/etc/kernelhunter` or locally in `~/.config/kernelhunter`.
 
 ## Configuration
 
-KernelHunter centralizes its configuration in `/etc/kernelhunter/config.json`.
-The file is created automatically when running the configuration helper:
+KernelHunter keeps its configuration in either `/etc/kernelhunter/config.json` or
+`~/.config/kernelhunter/config.json` depending on your installation choice. The
+file is created automatically during installation and can be inspected with:
 
 ```bash
 $ python kernelhunter_config.py --show
@@ -80,8 +81,9 @@ The configuration contains the path to the genetic reservoir directory and the
 OpenAI API key used by the analysis modules. You can update these values with:
 
 ```bash
-$ sudo python kernelhunter_config.py --reservoir-path /custom/reservoir
-$ sudo python kernelhunter_config.py --api-key YOUR_OPENAI_KEY
+# Use sudo only if modifying the global configuration
+python kernelhunter_config.py --reservoir-path /custom/reservoir
+python kernelhunter_config.py --api-key YOUR_OPENAI_KEY
 ```
 
 The `OPENAI_API_KEY` environment variable still takes precedence over the value

--- a/install_kernelhunter.sh
+++ b/install_kernelhunter.sh
@@ -22,6 +22,46 @@ if [[ "$EUID" -eq 0 ]]; then
     fi
 fi
 
+# Ask configuration scope
+echo ""
+echo "Choose configuration scope:"
+echo " 1) Global (/etc/kernelhunter)"
+echo " 2) Local  (~/.config/kernelhunter)"
+read -p "Scope [1/2]: " scope
+if [[ "$scope" == "1" ]]; then
+    CONFIG_DIR="/etc/kernelhunter"
+    RESERVOIR_DIR="/var/lib/kernelhunter/reservoir"
+    SUDO=""
+    if [[ "$EUID" -ne 0 ]]; then
+        SUDO="sudo"
+    fi
+else
+    CONFIG_DIR="$HOME/.config/kernelhunter"
+    RESERVOIR_DIR="$HOME/.local/share/kernelhunter/reservoir"
+    SUDO=""
+fi
+
+# Create configuration and reservoir directories
+$SUDO mkdir -p "$CONFIG_DIR"
+$SUDO mkdir -p "$RESERVOIR_DIR"
+
+if [[ "$scope" == "1" ]]; then
+    $SUDO chmod 1777 "$RESERVOIR_DIR"
+else
+    chmod 700 "$RESERVOIR_DIR"
+fi
+
+# Create initial config file
+tmpcfg=$(mktemp)
+cat > "$tmpcfg" <<EOF
+{
+    "reservoir_path": "$RESERVOIR_DIR",
+    "openai_api_key": ""
+}
+EOF
+$SUDO mv "$tmpcfg" "$CONFIG_DIR/config.json"
+$SUDO chmod 600 "$CONFIG_DIR/config.json"
+
 # Installation target
 INSTALL_DIR="$HOME/.local/share/kernelhunter"
 BIN_DIR="$HOME/.local/bin"


### PR DESCRIPTION
## Summary
- let installer ask for local/global config scope and set up reservoir and config file
- allow configuration module to load from global or per-user location
- document new behavior and update config instructions

## Testing
- `bash -n install_kernelhunter.sh`
- `python3 -m py_compile kernelhunter_config.py`


------
https://chatgpt.com/codex/tasks/task_e_6840016980288325ac020b12be30756e