### PR TITLE
Add config prompts to installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ cd kernelhunter
 
 # 2. Run the installer (no root required)
 python install_kernelhunter.py
+#    (you will be asked for your OpenAI API key)
 
 # 3. (Optional) Restart your terminal or run:
 source ~/.bashrc
@@ -67,6 +68,7 @@ kernelhunter
 The previous `install_kernelhunter.sh` script is now deprecated.
 
 After installation, KernelHunter will be available under `~/.local/bin/kernelhunter` for the current user. During installation you can choose whether the configuration is stored globally in `/etc/kernelhunter` or locally in `~/.config/kernelhunter`.
+The installer will also create an empty genetic reservoir if none is present.
 
 ## Configuration
 

--- a/install_kernelhunter.py
+++ b/install_kernelhunter.py
@@ -59,7 +59,8 @@ def main() -> None:
     except PermissionError:
         print(f"[!] Could not set permissions on {reservoir_dir}.")
 
-    config = {"reservoir_path": reservoir_dir, "openai_api_key": ""}
+    api_key = input("OpenAI API key (leave blank to skip): ").strip()
+    config = {"reservoir_path": reservoir_dir, "openai_api_key": api_key}
     config_file = os.path.join(config_dir, "config.json")
     with open(config_file, "w", encoding="utf-8") as f:
         json.dump(config, f, indent=4)
@@ -67,6 +68,15 @@ def main() -> None:
         os.chmod(config_file, 0o600)
     except PermissionError:
         print(f"[!] Could not set permissions on {config_file}.")
+
+    reservoir_file = os.path.join(reservoir_dir, "kernelhunter_reservoir.pkl")
+    if not os.path.exists(reservoir_file):
+        try:
+            from genetic_reservoir import GeneticReservoir
+
+            GeneticReservoir().save_to_file(reservoir_file)
+        except Exception as exc:
+            print(f"[!] Could not create reservoir file {reservoir_file}: {exc}")
 
     install_dir = os.path.join(home, ".local", "share", "kernelhunter")
     bin_dir = os.path.join(home, ".local", "bin")


### PR DESCRIPTION
## Summary
- ask for OpenAI key during installation
- create reservoir file if missing
- note this behavior in the README

## Testing
- `python -m py_compile install_kernelhunter.py`

------
https://chatgpt.com/codex/tasks/task_e_68401da842a883258a5caaf4b64d2783