### PR TITLE
Improve README and fix global reservoir permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ The previous `install_kernelhunter.sh` script is now deprecated.
 After installation, KernelHunter will be available under `~/.local/bin/kernelhunter` for the current user. During installation you can choose whether the configuration is stored globally in `/etc/kernelhunter` or locally in `~/.config/kernelhunter`.
 The installer will also create an empty genetic reservoir if none is present.
 
+If you choose a **global** installation, this reservoir lives in
+`/var/lib/kernelhunter/reservoir` and the directory is created with mode
+`1777`, allowing all users to write to it (similar to `/tmp`). This makes the
+reservoir shared across accounts but may not be desirable in hardened
+environments. A **local** installation (`--scope local`) keeps the reservoir
+private under your home directory.
+
 ## Configuration
 
 KernelHunter keeps its configuration in either `/etc/kernelhunter/config.json` or

--- a/install_kernelhunter.py
+++ b/install_kernelhunter.py
@@ -75,6 +75,13 @@ def main() -> None:
             from genetic_reservoir import GeneticReservoir
 
             GeneticReservoir().save_to_file(reservoir_file)
+            try:
+                if scope == "global":
+                    os.chmod(reservoir_file, 0o666)
+                else:
+                    os.chmod(reservoir_file, 0o600)
+            except PermissionError:
+                print(f"[!] Could not set permissions on {reservoir_file}.")
         except Exception as exc:
             print(f"[!] Could not create reservoir file {reservoir_file}: {exc}")
 


### PR DESCRIPTION
## Summary
- clarify that global installations create a world-writable reservoir directory
- set correct permissions on the reservoir file when installing

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840447531b083259b779a0070bfce5e