### PR TITLE
Improve attack mutation monitor layout

### DIFF
--- a/attack_mutation_monitor.py
+++ b/attack_mutation_monitor.py
@@ -3,6 +3,7 @@ import curses
 import json
 import os
 import time
+import math
 
 METRICS_FILE = "kernelhunter_metrics.json"
 
@@ -18,6 +19,33 @@ class AttackMutationMonitor:
         self.attack_totals = {}
         self.mutation_totals = {}
         self.last_refresh = 0
+
+    def _draw_items_in_columns(self, stdscr, row, col, items, available_width, max_rows):
+        """Helper to draw key/value pairs in columns to better use the screen."""
+        if not items:
+            return
+
+        # Prepare formatted strings
+        formatted = [f"{name}: {count}" for name, count in items]
+        if not formatted:
+            return
+
+        # Determine optimal column width
+        max_len = max(len(s) for s in formatted) + 2
+        num_cols = max(1, available_width // max_len)
+        rows_needed = math.ceil(len(formatted) / num_cols)
+
+        if rows_needed > max_rows and max_rows > 0:
+            num_cols = math.ceil(len(formatted) / max_rows)
+            rows_needed = math.ceil(len(formatted) / num_cols)
+            max_len = max(1, available_width // num_cols)
+
+        for idx, text in enumerate(formatted):
+            r = row + (idx % rows_needed)
+            c = col + (idx // rows_needed) * max_len
+            if r >= row + max_rows:
+                break
+            stdscr.addstr(r, c, text[:max_len - 1])
 
     def load_metrics(self):
         if os.path.exists(METRICS_FILE):
@@ -69,13 +97,24 @@ class AttackMutationMonitor:
         attack_items = sorted(attack.items(), key=lambda x: x[1], reverse=True)
         mut_items = sorted(mut.items(), key=lambda x: x[1], reverse=True)
         max_rows = height - row - 2
-        for i in range(max_rows):
-            if i < len(attack_items):
-                a_name, a_count = attack_items[i]
-                stdscr.addstr(row + i, 2, f"{a_name}: {a_count}")
-            if i < len(mut_items):
-                m_name, m_count = mut_items[i]
-                stdscr.addstr(row + i, width // 2, f"{m_name}: {m_count}")
+
+        half_width = width // 2 - 2
+        self._draw_items_in_columns(
+            stdscr,
+            row,
+            2,
+            attack_items,
+            half_width,
+            max_rows,
+        )
+        self._draw_items_in_columns(
+            stdscr,
+            row,
+            width // 2,
+            mut_items,
+            half_width,
+            max_rows,
+        )
 
         stdscr.addstr(height - 1, 0, "Press 'q' to quit")
         stdscr.refresh()


### PR DESCRIPTION
## Summary
- enhance attack_mutation_monitor to display data in columns

## Testing
- `python -m py_compile attack_mutation_monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_6841a1d159a08325bc9ceec718e7b4dc