### PR TITLE
Fix metrics persistence for monitoring

### DIFF
--- a/kernelHunter.py
+++ b/kernelHunter.py
@@ -227,8 +227,11 @@ mutation_counter = Counter()
 def write_metrics():
     """Persist current metrics to disk"""
     try:
-        write_metrics()
+        with open(METRICS_FILE, "w") as f:
+            json.dump(metrics, f, indent=2)
     except Exception:
+        # Silently ignore errors when persisting metrics so the fuzzer can
+        # continue running even if writing fails (e.g. due to filesystem issues)
         pass
 
 # Contador para generaciones consecutivas sin crashes por individuo


### PR DESCRIPTION
## Summary
- ensure metrics are written to disk

## Testing
- `python3 -m py_compile kernelHunter.py attack_mutation_monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_6841b97851fc832580f4fdff95a2b966