### PR TITLE
Fix menu execution path

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -3,6 +3,9 @@
 
 import curses
 import subprocess
+import os
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 MENU_ITEMS = [
     ("Run KernelHunter Fuzzer", "kernelHunter.py"),
@@ -48,7 +51,8 @@ def run_menu(stdscr):
             if label == "Quit":
                 break
             curses.endwin()
-            subprocess.call(["python3", script])
+            script_path = os.path.join(BASE_DIR, script)
+            subprocess.call(["python3", script_path])
             stdscr = curses.initscr()
             curses.curs_set(0)
             stdscr.keypad(True)


### PR DESCRIPTION
## Summary
- fix menu's script location logic so it works from any directory

## Testing
- `python3 -m py_compile menu.py`

------
https://chatgpt.com/codex/tasks/task_e_6842156193c483258d29a07fae908d82