### PR TITLE
Fix running menu tools from install path

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -52,7 +52,9 @@ def run_menu(stdscr):
                 break
             curses.endwin()
             script_path = os.path.join(BASE_DIR, script)
-            subprocess.call(["python3", script_path])
+            # Ensure each tool runs from the installation directory so that
+            # relative paths inside those scripts resolve correctly.
+            subprocess.call(["python3", script_path], cwd=BASE_DIR)
             stdscr = curses.initscr()
             curses.curs_set(0)
             stdscr.keypad(True)


### PR DESCRIPTION
## Summary
- ensure menu launches subtools from the KernelHunter install directory

## Testing
- `python3 -m py_compile menu.py`

------
https://chatgpt.com/codex/tasks/task_e_684218cea45c832589b31ec04c6d5f38