### PR TITLE
Add tmux launcher script

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,3 +189,17 @@ Use the arrow keys and Enter to select one of the following options:
 - Quit
 
 When a tool exits you will be returned to the menu.
+
+## tmux launcher
+
+The repository includes `tmux_launcher.sh` for quickly opening the monitoring tools in a grid of tmux panes. It requires `tmux` to be installed on your system.
+
+Run it from the repository root with:
+
+```bash
+./tmux_launcher.sh
+```
+
+This will start the KernelHunter monitor, the reservoir UI, the crash UI, and the dashboard in one tmux session arranged in two columns.
+
+

--- a/tmux_launcher.sh
+++ b/tmux_launcher.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Ensure tmux is installed
+if ! command -v tmux >/dev/null 2>&1; then
+    echo "Error: tmux is not installed. Please install tmux to run this launcher." >&2
+    exit 1
+fi
+
+# Resolve the directory of this script and switch to it
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+SESSION="kernelhunter"
+
+# Start tmux session and launch the monitoring tools
+# First pane: KernelHunter monitor
+ tmux new-session -d -s "$SESSION" "python3 kernel_hunter_monitor.py"
+
+# Second pane: Reservoir UI (split horizontally)
+ tmux split-window -h -t "$SESSION" "python3 reservoir_ui.py"
+
+# Third pane: Kernel crash UI (split vertically from pane 0)
+ tmux select-pane -t "$SESSION":0.0
+ tmux split-window -v -t "$SESSION" "python3 kernel_crash_ui.py"
+
+# Fourth pane: Kernel dashboard (split vertically from pane 1)
+ tmux select-pane -t "$SESSION":0.1
+ tmux split-window -v -t "$SESSION" "python3 kernel_dash.py"
+
+# Arrange panes in a tiled layout (2 columns, 2 rows)
+ tmux select-layout -t "$SESSION" tiled
+
+# Attach to the session
+ tmux attach-session -t "$SESSION"
+


### PR DESCRIPTION
## Summary
- add `tmux_launcher.sh` to start monitor scripts in a tmux grid
- document usage of the launcher in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `bash -n tmux_launcher.sh`

------
https://chatgpt.com/codex/tasks/task_e_684214e087c08325b792b1fd9dc7dcf9