### PR TITLE
Implement sliding window RL with exploration

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,12 @@ python kernelHunter.py --use-rl-weights
 ```
 
 When invoked with this flag, KernelHunter starts with the default weights and
-balances them after each execution based on observed crashes.
+uses a sliding window to track recent rewards. Attack and mutation selections
+follow an epsilon-greedy strategy to balance exploration and exploitation. The
+weights are updated according to the observed success rate and a learning rate.
 
-When reinforcement learning is active, updated weights are recorded in
-`kernelhunter_metrics.json` after each execution.
+Updated weights are recorded in `kernelhunter_metrics.json` after each
+generation.
 
 
 


### PR DESCRIPTION
## Summary
- improve reinforcement learning logic
- add sliding window reward tracking and epsilon-greedy choices
- compute rewards based on crash type and system impact
- update README with new RL description

## Testing
- `python -m py_compile kernelHunter.py`

------
https://chatgpt.com/codex/tasks/task_e_6842ba8aaa6483258db2005f353eae52