### PR TITLE
Remove unnecessary pause in kernelHunter

### DIFF
--- a/kernelHunter.py
+++ b/kernelHunter.py
@@ -1632,7 +1632,6 @@ def main():
         for gen in range(MAX_GENERATIONS):
             print(f"\nGeneración {gen}/{MAX_GENERATIONS} (población: {len(population)})")
             population = run_generation(gen, population)
-            time.sleep(0.2)
 
     except KeyboardInterrupt:
         print("\n\nProceso interrumpido por el usuario.")


### PR DESCRIPTION
## Summary
- remove `time.sleep(0.2)` after each generation in `kernelHunter.py`

This speeds up fuzzing by skipping an unnecessary delay between generations.

## Testing
- `python -m py_compile kernelHunter.py`
- `python -m py_compile kernel_dash.py`

------
https://chatgpt.com/codex/tasks/task_e_6842f0fadedc8325b1aa871d366fda52