### PR TITLE
Fix weight metrics when RL disabled

### DIFF
--- a/kernelHunter.py
+++ b/kernelHunter.py
@@ -421,14 +421,17 @@ def write_metrics():
         pass
 
 def update_rl_weights():
-    """Record current Q-values for analysis."""
-    if not USE_RL_WEIGHTS:
-        return
+    """Record current weight values for analysis."""
 
-    metrics.setdefault("attack_weights_history", []).append(list(attack_q_values))
-    metrics.setdefault("mutation_weights_history", []).append(list(mutation_q_values))
-    attack_success.clear()
-    mutation_success.clear()
+    if USE_RL_WEIGHTS:
+        metrics.setdefault("attack_weights_history", []).append(list(attack_q_values))
+        metrics.setdefault("mutation_weights_history", []).append(list(mutation_q_values))
+        attack_success.clear()
+        mutation_success.clear()
+    else:
+        metrics.setdefault("attack_weights_history", []).append(list(attack_weights))
+        metrics.setdefault("mutation_weights_history", []).append(list(mutation_weights))
+
     write_metrics()
 
 # Contador para generaciones consecutivas sin crashes por individuo


### PR DESCRIPTION
## Summary
- track attack and mutation weights even when RL mode is off

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68430bea715c83258553e219a3e47528