### PR TITLE
Fix logging to write CSV rows

### DIFF
--- a/kernelHunter.py
+++ b/kernelHunter.py
@@ -1726,19 +1726,38 @@ def run_generation(gen_id, base_population):
     print(color_text(f"[GEN {gen_id}] Crash rate: {crash_rate*100:.1f}% | Sys impacts: {system_impacts} | Avg length: {avg_length:.1f}", "cyan"))
     print(color_text(f"[GEN {gen_id}] Crash types: {dict(crash_types_counter.most_common(3))}", "cyan"))
 
-    try:
-        pythonlogger.log_generation(
-            generation_id=gen_id,
-            population_size=len(base_population),
-            crash_rate=crash_rate,
-            system_impacts=system_impacts,
-            avg_shellcode_length=avg_length,
-            crash_types=dict(crash_types_counter),
-            attack_stats=dict(generation_attack_counter),
-            mutation_stats=dict(generation_mutation_counter)
-        )
-    except Exception as e:
-        print(f"[WARNING] Error logging generation: {e}")
+    rl_data = {
+        "attack_q_values": list(attack_q_values),
+        "mutation_q_values": list(mutation_q_values),
+        "epsilon": get_epsilon(gen_id)
+    } if USE_RL_WEIGHTS else {
+        "attack_weights": attack_weights,
+        "mutation_weights": mutation_weights,
+        "epsilon": get_epsilon(gen_id)
+    }
+
+    diversity_data = genetic_reservoir.get_diversity_stats()
+
+    print(f"[DEBUG] Llamando a log_generation con gen_id={gen_id}")
+    print(f"[DEBUG] population_size={len(base_population)} crash_rate={crash_rate} system_impacts={system_impacts} avg_len={avg_length}")
+    print(f"[DEBUG] crash_types={dict(crash_types_counter)}")
+    print(f"[DEBUG] attack_stats={dict(generation_attack_counter)}")
+    print(f"[DEBUG] mutation_stats={dict(generation_mutation_counter)}")
+    print(f"[DEBUG] rl_data={rl_data}")
+    print(f"[DEBUG] diversity_data={diversity_data}")
+
+    pythonlogger.log_generation(
+        generation_id=gen_id,
+        population_size=len(base_population),
+        crash_rate=crash_rate,
+        system_impacts=system_impacts,
+        avg_shellcode_length=avg_length,
+        crash_types=dict(crash_types_counter),
+        attack_stats=dict(generation_attack_counter),
+        mutation_stats=dict(generation_mutation_counter),
+        rl_weights=rl_data,
+        diversity_metrics=diversity_data
+    )
 
     # Actualizar métricas
     metrics["generations"].append(gen_id)

--- a/performance_logger.py
+++ b/performance_logger.py
@@ -125,6 +125,7 @@ class PerformanceLogger:
         
         # Escribir a CSV inmediatamente
         try:
+            print(f"[PerformanceLogger][DEBUG] Llamando _write_csv_row con datos: {generation_data}")
             self._write_csv_row(generation_data)
             print(f"[PerformanceLogger] Fila CSV agregada para gen {generation_id}")
         except Exception as e:
@@ -326,14 +327,23 @@ class PerformanceLogger:
                 generation_data["avg_shellcode_length"],
                 generation_data["total_crashes"],
                 generation_data["unique_crash_types"],
-                generation_data["diversity_metrics"].get("diversity_avg", 0) if generation_data["diversity_metrics"] else 0,
-                generation_data["rl_weights"].get("epsilon", 0) if generation_data["rl_weights"] else 0
+                generation_data.get("diversity_metrics", {}).get("diversity_avg", 0),
+                generation_data.get("rl_weights", {}).get("epsilon", 0)
             ]
-            
+
+            if not os.path.exists(PERFORMANCE_CSV_FILE):
+                print("[PerformanceLogger][DEBUG] CSV no existe, reinicializando...")
+                self._init_csv_file()
+
             with open(PERFORMANCE_CSV_FILE, 'a', newline='') as f:
                 writer = csv.writer(f)
                 writer.writerow(row)
-                
+                f.flush()
+                os.fsync(f.fileno())
+
+            size = os.path.getsize(PERFORMANCE_CSV_FILE)
+            print(f"[PerformanceLogger][DEBUG] Fila escrita. Tama\u00f1o del CSV: {size} bytes")
+
         except Exception as e:
             print(f"[PerformanceLogger] ERROR escribiendo fila CSV: {e}")
             raise


### PR DESCRIPTION
## Summary
- log generation details with RL and diversity metrics
- add debug output for each log_generation call
- make `_write_csv_row` safer and ensure CSV writes flush to disk

## Testing
- `python3 performance_logger.py >/tmp/perf_test.log && tail -n 20 /tmp/perf_test.log`
- `python3 -m py_compile performance_logger.py kernelHunter.py`

------
https://chatgpt.com/codex/tasks/task_e_684349a9af5c8325a3d82ba84aefa4d5